### PR TITLE
handle namespaces ending with a semicolon comment without a newline

### DIFF
--- a/src/hansel/instrument/utils.clj
+++ b/src/hansel/instrument/utils.clj
@@ -30,7 +30,7 @@
 
 (defn file-forms-fn-clj [ns-symb file-url _]
   (binding [*ns* (find-ns ns-symb)]
-    (->> (format "[%s]" (slurp file-url))
+    (->> (format "[%s\n]" (slurp file-url))
         (read-string {:read-cond :allow}))))
 
 (defn file-forms-fn-cljs  [ns-symb file-url {:keys [build-id]}]


### PR DESCRIPTION
a namespace ending with a semicolon comment without a newline breaks the parser.